### PR TITLE
Remove SFINAE in some places

### DIFF
--- a/include/openPMD/DatatypeHelpers.hpp
+++ b/include/openPMD/DatatypeHelpers.hpp
@@ -83,6 +83,7 @@ struct CallUndefinedDatatype
         {
             return Action::template call< n >( std::forward< Args >( args )... );
         }
+        throw std::runtime_error( "Unreachable!" );
     }
 };
 }

--- a/include/openPMD/DatatypeHelpers.hpp
+++ b/include/openPMD/DatatypeHelpers.hpp
@@ -63,41 +63,26 @@ struct HasErrorMessageMember<
  * @tparam n As in switchType().
  * @tparam ReturnType As in switchType().
  * @tparam Action As in switchType().
- * @tparam Placeholder For SFINAE, set to void.
  * @tparam Args As in switchType().
  */
 template<
     int n,
     typename ReturnType,
     typename Action,
-    typename Placeholder,
     typename... Args >
 struct CallUndefinedDatatype
 {
-    static ReturnType call( Args &&... )
-    {
-        static_assert(
-            HasErrorMessageMember< Action >::value,
-            "[switchType] Action needs either an errorMsg member of type "
-            "std::string or operator()<unsigned>() overloads." );
-        throw std::runtime_error(
-            "[" + std::string( Action::errorMsg ) + "] Unknown Datatype." );
-    }
-};
-
-template< int n, typename ReturnType, typename Action, typename... Args >
-struct CallUndefinedDatatype<
-    n,
-    ReturnType,
-    Action,
-    // Enable this, if no error message member is found.
-    // action.template operator()<n>() will be called instead
-    typename std::enable_if< !HasErrorMessageMember< Action >::value >::type,
-    Args... >
-{
     static ReturnType call( Args &&... args )
     {
-        return Action::template call< n >( std::forward< Args >( args )... );
+        if constexpr( HasErrorMessageMember< Action >::value )
+        {
+            throw std::runtime_error(
+                "[" + std::string( Action::errorMsg ) + "] Unknown Datatype." );
+        }
+        else
+        {
+            return Action::template call< n >( std::forward< Args >( args )... );
+        }
     }
 };
 }
@@ -235,7 +220,6 @@ auto switchType( Datatype dt, Args &&... args )
             0,
             ReturnType,
             Action,
-            void,
             Args &&... >::call( std::forward< Args >( args )... );
     default:
         throw std::runtime_error(
@@ -323,7 +307,6 @@ auto switchNonVectorType( Datatype dt, Args &&... args )
             0,
             ReturnType,
             Action,
-            void,
             Args &&... >::call( std::forward< Args >( args )... );
     default:
         throw std::runtime_error(

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -197,7 +197,6 @@ auto switchAdios2AttributeType( Datatype dt, Args &&... args )
             0,
             ReturnType,
             Action,
-            void,
             Args &&... >::call( std::forward< Args >( args )... );
     default:
         throw std::runtime_error(
@@ -284,7 +283,6 @@ auto switchAdios2VariableType( Datatype dt, Args &&... args )
             0,
             ReturnType,
             Action,
-            void,
             Args &&... >::
             call( std::forward< Args >( args )... );
     default:

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -441,6 +441,37 @@ namespace detail
 {
     // Helper structs for calls to the switchType function
 
+    template< typename > struct IsVector
+    {
+        static constexpr bool value = false;
+    };
+
+    template< typename T > struct IsVector< std::vector< T > >
+    {
+        static constexpr bool value = true;
+    };
+
+    template< typename T >
+    inline constexpr bool IsVector_v = IsVector< T >::value;
+
+    template< typename > struct IsArray
+    {
+        static constexpr bool value = false;
+    };
+
+    template< typename T, size_t n > struct IsArray< std::array< T, n > >
+    {
+        static constexpr bool value = true;
+    };
+
+    template< typename T >
+    inline constexpr bool IsArray_v = IsArray< T >::value;
+
+    template< typename T >
+    inline constexpr bool IsUnsupportedComplex_v =
+        std::is_same_v< T, std::complex< long double > > ||
+        std::is_same_v< T, std::vector< std::complex< long double > > >;
+
     struct DatasetReader
     {
         template< typename T >
@@ -583,18 +614,6 @@ namespace detail
     struct AttributeTypes
     {
         static void
-        oldCreateAttribute(
-            adios2::IO & IO,
-            std::string name,
-            T value );
-
-        static void
-        oldReadAttribute(
-            adios2::IO & IO,
-            std::string name,
-            std::shared_ptr< Attribute::resource > resource );
-
-        static void
         createAttribute(
             adios2::IO & IO,
             adios2::Engine & engine,
@@ -631,26 +650,6 @@ namespace detail
     template< > struct AttributeTypes< std::complex< long double > >
     {
         static void
-        oldCreateAttribute(
-            adios2::IO &,
-            std::string,
-            std::complex< long double > )
-        {
-            throw std::runtime_error(
-                "[ADIOS2] Internal error: no support for long double complex attribute types" );
-        }
-
-        static void
-        oldReadAttribute(
-            adios2::IO &,
-            std::string,
-            std::shared_ptr< Attribute::resource > )
-        {
-            throw std::runtime_error(
-                "[ADIOS2] Internal error: no support for long double complex attribute types" );
-        }
-
-        static void
         createAttribute(
             adios2::IO &,
             adios2::Engine &,
@@ -682,26 +681,6 @@ namespace detail
 
     template< > struct AttributeTypes< std::vector< std::complex< long double > > >
     {
-        static void
-        oldCreateAttribute(
-            adios2::IO &,
-            std::string,
-            const std::vector< std::complex< long double > > & )
-        {
-            throw std::runtime_error(
-                "[ADIOS2] Internal error: no support for long double complex vector attribute types" );
-        }
-
-        static void
-        oldReadAttribute(
-            adios2::IO &,
-            std::string,
-            std::shared_ptr< Attribute::resource > )
-        {
-            throw std::runtime_error(
-                "[ADIOS2] Internal error: no support for long double complex vector attribute types" );
-        }
-
         static void
         createAttribute(
             adios2::IO &,
@@ -736,18 +715,6 @@ namespace detail
 
     template < typename T > struct AttributeTypes< std::vector< T > >
     {
-        static void
-        oldCreateAttribute(
-            adios2::IO & IO,
-            std::string name,
-            const std::vector< T > & value );
-
-        static void
-        oldReadAttribute(
-            adios2::IO & IO,
-            std::string name,
-            std::shared_ptr< Attribute::resource > resource );
-
         static void
         createAttribute(
             adios2::IO & IO,
@@ -792,18 +759,6 @@ namespace detail
     struct AttributeTypes< std::vector< std::string > >
     {
         static void
-        oldCreateAttribute(
-            adios2::IO & IO,
-            std::string name,
-            const std::vector< std::string > & value );
-
-        static void
-        oldReadAttribute(
-            adios2::IO & IO,
-            std::string name,
-            std::shared_ptr< Attribute::resource > resource );
-
-        static void
         createAttribute(
             adios2::IO & IO,
             adios2::Engine & engine,
@@ -847,18 +802,6 @@ namespace detail
     struct AttributeTypes< std::array< T, n > >
     {
         static void
-        oldCreateAttribute(
-            adios2::IO & IO,
-            std::string name,
-            const std::array< T, n > & value );
-
-        static void
-        oldReadAttribute(
-            adios2::IO & IO,
-            std::string name,
-            std::shared_ptr< Attribute::resource > resource );
-
-        static void
         createAttribute(
             adios2::IO & IO,
             adios2::Engine & engine,
@@ -898,18 +841,36 @@ namespace detail
         }
     };
 
+    namespace bool_repr
+    {
+        using rep = detail::bool_representation;
+
+        static constexpr rep toRep( bool b )
+        {
+            return b ? 1U : 0U;
+        }
+
+
+        static constexpr bool fromRep( rep r )
+        {
+            return r != 0;
+        }
+    }
+
     template <> struct AttributeTypes< bool >
     {
         using rep = detail::bool_representation;
 
-        static void
-        oldCreateAttribute( adios2::IO & IO, std::string name, bool value );
+        static constexpr rep toRep( bool b )
+        {
+            return b ? 1U : 0U;
+        }
 
-        static void
-        oldReadAttribute(
-            adios2::IO & IO,
-            std::string name,
-            std::shared_ptr< Attribute::resource > resource );
+
+        static constexpr bool fromRep( rep r )
+        {
+            return r != 0;
+        }
 
         static void
         createAttribute(
@@ -925,16 +886,6 @@ namespace detail
             std::shared_ptr< Attribute::resource > resource );
 
 
-        static constexpr rep toRep( bool b )
-        {
-            return b ? 1U : 0U;
-        }
-
-
-        static constexpr bool fromRep( rep r )
-        {
-            return r != 0;
-        }
 
         static bool
         attributeUnchanged( adios2::IO & IO, std::string name, bool val )


### PR DESCRIPTION
With `if constexpr` we can now often avoid SFINAE constructs, making code easier to read and faster to compile

* One instance can be removed in the implementation of switchType
* The `AttributeTypes` class in ADIOS2 uses specializations to enable different implementations of attributes based on type. This has always been annoying to read because each function was defined like 10 times.
  Not yet inlined: `attributeUnchanged` (will do), `(new)createAttribute, (new)readAttribute` (won't do, these will be removed anyway along with the new schema).
  The `AttributeTypes` class can then fully be removed.

TODO: Remove SFINAE and similar constructs in other places. Search for `enable_if`.