### PR TITLE
Release 0.14.5 conflicting backports

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -101,7 +101,12 @@ protected:
         m_openWriteFileHandles;
     std::unordered_map<std::shared_ptr<std::string>, ADIOS_FILE *>
         m_openReadFileHandles;
-    std::unordered_map<ADIOS_FILE *, std::vector<ADIOS_SELECTION *> >
+    struct ScheduledRead
+    {
+        ADIOS_SELECTION *selection;
+        std::shared_ptr<void> data; // needed to avoid early freeing
+    };
+    std::unordered_map<ADIOS_FILE *, std::vector<ScheduledRead> >
         m_scheduledReads;
     std::unordered_map<int64_t, std::unordered_map<std::string, Attribute> >
         m_attributeWrites;

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -103,7 +103,12 @@ protected:
         m_openWriteFileHandles;
     std::unordered_map<std::shared_ptr<std::string>, ADIOS_FILE *>
         m_openReadFileHandles;
-    std::unordered_map<ADIOS_FILE *, std::vector<ADIOS_SELECTION *> >
+    struct ScheduledRead
+    {
+        ADIOS_SELECTION *selection;
+        std::shared_ptr<void> data; // needed to avoid early freeing
+    };
+    std::unordered_map<ADIOS_FILE *, std::vector<ScheduledRead> >
         m_scheduledReads;
     std::unordered_map<int64_t, std::unordered_map<std::string, Attribute> >
         m_attributeWrites;

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -468,7 +468,8 @@ Attributable::setAttribute(std::string const &key, char const value[])
         key, value, internal::SetAttributeMode::FromPublicAPICall);
 }
 
-// TODO explicitly instantiate Attributable::setAttribute for all T in Datatype
+// note: we explicitly instantiate Attributable::setAttributeImpl for all T in
+// Datatype in Attributable.cpp
 template <typename T>
 inline bool Attributable::setAttributeImpl(
     std::string const &key,

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -85,21 +85,37 @@ namespace internal
         A_MAP m_attributes;
     };
 
+    enum class SetAttributeMode : char
+    {
+        WhileReadingAttributes,
+        FromPublicAPICall
+    };
+
     /** Verify values of attributes in the frontend
      *
      * verify string attributes are not empty (backend restriction, e.g., HDF5)
      */
     template <typename T>
-    inline void attr_value_check(std::string const /* key */, T /* value */)
+    inline void attr_value_check(
+        std::string const /* key */, T /* value */, SetAttributeMode)
     {}
 
     template <>
-    inline void attr_value_check(std::string const key, std::string const value)
+    inline void attr_value_check(
+        std::string const key, std::string const value, SetAttributeMode mode)
     {
-        if (value.empty())
-            throw std::runtime_error(
-                "[setAttribute] Value for string attribute '" + key +
-                "' must not be empty!");
+        switch (mode)
+        {
+        case SetAttributeMode::FromPublicAPICall:
+            if (value.empty())
+                throw std::runtime_error(
+                    "[setAttribute] Value for string attribute '" + key +
+                    "' must not be empty!");
+            break;
+        case SetAttributeMode::WhileReadingAttributes:
+            // no checks while reading
+            break;
+        }
     }
 
 } // namespace internal
@@ -267,6 +283,13 @@ public:
     void seriesFlush(internal::FlushParams);
 
     void flushAttributes(internal::FlushParams const &);
+
+    template <typename T>
+    bool setAttributeImpl(
+        std::string const &key, T value, internal::SetAttributeMode);
+    bool setAttributeImpl(
+        std::string const &key, char const value[], internal::SetAttributeMode);
+
     enum ReadMode
     {
         /**
@@ -431,11 +454,28 @@ public:
     }
 };
 
-// TODO explicitly instantiate Attributable::setAttribute for all T in Datatype
 template <typename T>
 inline bool AttributableInterface::setAttribute(std::string const &key, T value)
 {
-    internal::attr_value_check(key, value);
+    return setAttributeImpl(
+        key, std::move(value), internal::SetAttributeMode::FromPublicAPICall);
+}
+
+inline bool
+Attributable::setAttribute(std::string const &key, char const value[])
+{
+    return setAttributeImpl(
+        key, value, internal::SetAttributeMode::FromPublicAPICall);
+}
+
+// TODO explicitly instantiate Attributable::setAttribute for all T in Datatype
+template <typename T>
+inline bool Attributable::setAttributeImpl(
+    std::string const &key,
+    T value,
+    internal::SetAttributeMode setAttributeMode)
+{
+    internal::attr_value_check(key, value, setAttributeMode);
 
     auto &attri = get();
     if (IOHandler() && Access::READ_ONLY == IOHandler()->m_frontendAccess)
@@ -468,10 +508,12 @@ inline bool AttributableInterface::setAttribute(std::string const &key, T value)
     }
 }
 
-inline bool
-AttributableInterface::setAttribute(std::string const &key, char const value[])
+inline bool Attributable::setAttributeImpl(
+    std::string const &key,
+    char const value[],
+    internal::SetAttributeMode setAttributeMode)
 {
-    return this->setAttribute(key, std::string(value));
+    return this->setAttributeImpl(key, std::string(value), setAttributeMode);
 }
 
 template <typename T>

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -296,7 +296,7 @@ std::future<void> ADIOS1IOHandlerImpl::flush()
             "dataset reading");
 
         for (auto &sel : file.second)
-            adios_selection_delete(sel);
+            adios_selection_delete(sel.selection);
     }
     m_scheduledReads.clear();
 

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -639,7 +639,7 @@ void CommonADIOS1IOHandlerImpl::closeFile(
                 "dataset reading");
 
             for (auto &sel : scheduled->second)
-                adios_selection_delete(sel);
+                adios_selection_delete(sel.selection);
             m_scheduledReads.erase(scheduled);
         }
         close(handle_read->second);
@@ -1083,7 +1083,7 @@ void CommonADIOS1IOHandlerImpl::readDataset(
         "[ADIOS1] Internal error: Failed to schedule ADIOS read during dataset "
         "reading");
 
-    m_scheduledReads[f].push_back(sel);
+    m_scheduledReads[f].push_back({sel, parameters.data});
 }
 
 void CommonADIOS1IOHandlerImpl::readAttribute(

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -320,7 +320,7 @@ std::future<void> ParallelADIOS1IOHandlerImpl::flush()
             "dataset reading");
 
         for (auto &sel : file.second)
-            adios_selection_delete(sel);
+            adios_selection_delete(sel.selection);
     }
     m_scheduledReads.clear();
 

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -29,8 +29,32 @@
 #include "openPMD/IO/JSON/JSONIOHandler.hpp"
 #include "openPMD/auxiliary/JSON.hpp"
 
+#include <memory>
+#include <utility>
+
 namespace openPMD
 {
+
+namespace
+{
+    template <typename Backend, bool enabled, typename... Args>
+    std::shared_ptr<Backend>
+    constructIOHandler(std::string const &backendName, Args &&...args)
+    {
+        if /* constexpr */ (enabled)
+        {
+            return std::make_shared<Backend>(std::forward<Args>(args)...);
+        }
+        else
+        {
+            throw std::runtime_error(
+                "openPMD-api built without support for "
+                "backend '" +
+                backendName + "'.");
+        }
+    }
+} // namespace
+
 #if openPMD_HAVE_MPI
 template <>
 std::shared_ptr<AbstractIOHandler> createIOHandler<nlohmann::json>(
@@ -44,23 +68,24 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<nlohmann::json>(
     switch (format)
     {
     case Format::HDF5:
-        return std::make_shared<ParallelHDF5IOHandler>(
-            path, access, comm, std::move(options));
+        return constructIOHandler<ParallelHDF5IOHandler, openPMD_HAVE_HDF5>(
+            "HDF5", path, access, comm, std::move(options));
     case Format::ADIOS1:
 #if openPMD_HAVE_ADIOS1
-        return std::make_shared<ParallelADIOS1IOHandler>(path, access, comm);
+        return constructIOHandler<ParallelADIOS1IOHandler, openPMD_HAVE_ADIOS1>(
+            "ADIOS1", path, access, comm);
 #else
         throw std::runtime_error("openPMD-api built without ADIOS1 support");
 #endif
     case Format::ADIOS2:
-        return std::make_shared<ADIOS2IOHandler>(
-            path, access, comm, std::move(options), "bp4");
+        return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
+            "ADIOS2", path, access, comm, std::move(options), "bp4");
     case Format::ADIOS2_SST:
-        return std::make_shared<ADIOS2IOHandler>(
-            path, access, comm, std::move(options), "sst");
+        return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
+            "ADIOS2", path, access, comm, std::move(options), "sst");
     case Format::ADIOS2_SSC:
-        return std::make_shared<ADIOS2IOHandler>(
-            path, access, comm, std::move(options), "ssc");
+        return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
+            "ADIOS2", path, access, comm, std::move(options), "ssc");
     default:
         throw std::runtime_error(
             "Unknown file format! Did you specify a file ending?");
@@ -76,27 +101,29 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<nlohmann::json>(
     switch (format)
     {
     case Format::HDF5:
-        return std::make_shared<HDF5IOHandler>(
-            path, access, std::move(options));
+        return constructIOHandler<HDF5IOHandler, openPMD_HAVE_HDF5>(
+            "HDF5", path, access, std::move(options));
     case Format::ADIOS1:
 #if openPMD_HAVE_ADIOS1
-        return std::make_shared<ADIOS1IOHandler>(path, access);
+        return constructIOHandler<ADIOS1IOHandler, openPMD_HAVE_ADIOS1>(
+            "ADIOS1", path, access);
 #else
         throw std::runtime_error("openPMD-api built without ADIOS1 support");
 #endif
 #if openPMD_HAVE_ADIOS2
     case Format::ADIOS2:
-        return std::make_shared<ADIOS2IOHandler>(
-            path, access, std::move(options), "bp4");
+        return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
+            "ADIOS2", path, access, std::move(options), "bp4");
     case Format::ADIOS2_SST:
-        return std::make_shared<ADIOS2IOHandler>(
-            path, access, std::move(options), "sst");
+        return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
+            "ADIOS2", path, access, std::move(options), "sst");
     case Format::ADIOS2_SSC:
-        return std::make_shared<ADIOS2IOHandler>(
-            path, access, std::move(options), "ssc");
-#endif // openPMD_HAVE_ADIOS2
+        return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
+            "ADIOS2", path, access, std::move(options), "ssc");
+#endif
     case Format::JSON:
-        return std::make_shared<JSONIOHandler>(path, access);
+        return constructIOHandler<JSONIOHandler, openPMD_HAVE_JSON>(
+            "JSON", path, access);
     default:
         throw std::runtime_error(
             "Unknown file format! Did you specify a file ending?");

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -52,6 +52,7 @@ namespace
                 "backend '" +
                 backendName + "'.");
         }
+        throw "Unreachable";
     }
 } // namespace
 

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -309,96 +309,183 @@ void AttributableInterface::readAttributes(ReadMode mode)
                 }
                 std::array<double, 7> arr;
                 std::copy_n(vector.begin(), 7, arr.begin());
-                setAttribute(key, std::move(arr));
+                setAttributeImpl(
+                    key,
+                    std::move(arr),
+                    internal::SetAttributeMode::WhileReadingAttributes);
             }
             else
             {
-                setAttribute(key, std::move(vector));
+                setAttributeImpl(
+                    key,
+                    std::move(vector),
+                    internal::SetAttributeMode::WhileReadingAttributes);
             }
         };
 
         switch (*aRead.dtype)
         {
         case DT::CHAR:
-            setAttribute(att, a.get<char>());
+            setAttributeImpl(
+                att,
+                a.get<char>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::UCHAR:
-            setAttribute(att, a.get<unsigned char>());
+            setAttributeImpl(
+                att,
+                a.get<unsigned char>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::SHORT:
-            setAttribute(att, a.get<short>());
+            setAttributeImpl(
+                att,
+                a.get<short>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::INT:
-            setAttribute(att, a.get<int>());
+            setAttributeImpl(
+                att,
+                a.get<int>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::LONG:
-            setAttribute(att, a.get<long>());
+            setAttributeImpl(
+                att,
+                a.get<long>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::LONGLONG:
-            setAttribute(att, a.get<long long>());
+            setAttributeImpl(
+                att,
+                a.get<long long>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::USHORT:
-            setAttribute(att, a.get<unsigned short>());
+            setAttributeImpl(
+                att,
+                a.get<unsigned short>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::UINT:
-            setAttribute(att, a.get<unsigned int>());
+            setAttributeImpl(
+                att,
+                a.get<unsigned int>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::ULONG:
-            setAttribute(att, a.get<unsigned long>());
+            setAttributeImpl(
+                att,
+                a.get<unsigned long>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::ULONGLONG:
-            setAttribute(att, a.get<unsigned long long>());
+            setAttributeImpl(
+                att,
+                a.get<unsigned long long>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::FLOAT:
-            setAttribute(att, a.get<float>());
+            setAttributeImpl(
+                att,
+                a.get<float>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::DOUBLE:
-            setAttribute(att, a.get<double>());
+            setAttributeImpl(
+                att,
+                a.get<double>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::LONG_DOUBLE:
-            setAttribute(att, a.get<long double>());
+            setAttributeImpl(
+                att,
+                a.get<long double>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::CFLOAT:
-            setAttribute(att, a.get<std::complex<float> >());
+            setAttributeImpl(
+                att,
+                a.get<std::complex<float> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::CDOUBLE:
-            setAttribute(att, a.get<std::complex<double> >());
+            setAttributeImpl(
+                att,
+                a.get<std::complex<double> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::CLONG_DOUBLE:
-            setAttribute(att, a.get<std::complex<long double> >());
+            setAttributeImpl(
+                att,
+                a.get<std::complex<long double> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::STRING:
-            setAttribute(att, a.get<std::string>());
+            setAttributeImpl(
+                att,
+                a.get<std::string>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_CHAR:
-            setAttribute(att, a.get<std::vector<char> >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<char> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_SHORT:
-            setAttribute(att, a.get<std::vector<short> >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<short> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_INT:
-            setAttribute(att, a.get<std::vector<int> >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<int> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_LONG:
-            setAttribute(att, a.get<std::vector<long> >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<long> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_LONGLONG:
-            setAttribute(att, a.get<std::vector<long long> >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<long long> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_UCHAR:
-            setAttribute(att, a.get<std::vector<unsigned char> >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<unsigned char> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_USHORT:
-            setAttribute(att, a.get<std::vector<unsigned short> >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<unsigned short> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_UINT:
-            setAttribute(att, a.get<std::vector<unsigned int> >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<unsigned int> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_ULONG:
-            setAttribute(att, a.get<std::vector<unsigned long> >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<unsigned long> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_ULONGLONG:
-            setAttribute(att, a.get<std::vector<unsigned long long> >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<unsigned long long> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_FLOAT:
             guardUnitDimension(att, a.get<std::vector<float> >());
@@ -410,23 +497,38 @@ void AttributableInterface::readAttributes(ReadMode mode)
             guardUnitDimension(att, a.get<std::vector<long double> >());
             break;
         case DT::VEC_CFLOAT:
-            setAttribute(att, a.get<std::vector<std::complex<float> > >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<std::complex<float> > >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_CDOUBLE:
-            setAttribute(att, a.get<std::vector<std::complex<double> > >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<std::complex<double> > >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_CLONG_DOUBLE:
             setAttribute(
                 att, a.get<std::vector<std::complex<long double> > >());
             break;
         case DT::VEC_STRING:
-            setAttribute(att, a.get<std::vector<std::string> >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<std::string> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::ARR_DBL_7:
-            setAttribute(att, a.get<std::array<double, 7> >());
+            setAttributeImpl(
+                att,
+                a.get<std::array<double, 7> >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::BOOL:
-            setAttribute(att, a.get<bool>());
+            setAttributeImpl(
+                att,
+                a.get<bool>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::DATATYPE:
         case DT::UNDEFINED:

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -509,8 +509,10 @@ void AttributableInterface::readAttributes(ReadMode mode)
                 internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_CLONG_DOUBLE:
-            setAttribute(
-                att, a.get<std::vector<std::complex<long double> > >());
+            setAttributeImpl(
+                att,
+                a.get<std::vector<std::complex<long double> > >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_STRING:
             setAttributeImpl(

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1185,3 +1185,28 @@ TEST_CASE("DoConvert_single_value_to_vector", "[core]")
             std::vector<int>{0, 1, 2, 3, 4, 5, 6});
     }
 }
+
+TEST_CASE("unavailable_backend", "[core]")
+{
+#if !openPMD_HAVE_ADIOS1 && !openPMD_HAVE_ADIOS2
+    {
+        auto fail = []() { Series("unavailable.bp", Access::CREATE); };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "openPMD-api built without support for backend "
+            "'ADIOS2'.");
+    }
+#endif
+
+#if openPMD_HAVE_MPI && !openPMD_HAVE_ADIOS1 && !openPMD_HAVE_ADIOS2
+    {
+        auto fail = []() {
+            Series("unavailable.bp", Access::CREATE, MPI_COMM_WORLD);
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "openPMD-api built without support for backend "
+            "'ADIOS2'.");
+    }
+#endif
+}

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1185,28 +1185,3 @@ TEST_CASE("DoConvert_single_value_to_vector", "[core]")
             std::vector<int>{0, 1, 2, 3, 4, 5, 6});
     }
 }
-
-TEST_CASE("unavailable_backend", "[core]")
-{
-#if !openPMD_HAVE_ADIOS1 && !openPMD_HAVE_ADIOS2
-    {
-        auto fail = []() { Series("unavailable.bp", Access::CREATE); };
-        REQUIRE_THROWS_WITH(
-            fail(),
-            "openPMD-api built without support for backend "
-            "'ADIOS2'.");
-    }
-#endif
-
-#if openPMD_HAVE_MPI && !openPMD_HAVE_ADIOS1 && !openPMD_HAVE_ADIOS2
-    {
-        auto fail = []() {
-            Series("unavailable.bp", Access::CREATE, MPI_COMM_WORLD);
-        };
-        REQUIRE_THROWS_WITH(
-            fail(),
-            "openPMD-api built without support for backend "
-            "'ADIOS2'.");
-    }
-#endif
-}

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -385,9 +385,11 @@ TEST_CASE("multiple_series_handles_test", "[serial]")
     /*
      * clang also understands these pragmas.
      */
-#if defined(__GNUC__MINOR__) || defined(__clang__)
+#if defined(__GNUC_MINOR__) && !defined(__INTEL_COMPILER)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__clang__)
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
     /*
      * First test: No premature flushes through destructor when another copy
@@ -431,11 +433,10 @@ TEST_CASE("multiple_series_handles_test", "[serial]")
          */
         series_ptr->flush();
     }
-#if defined(__INTEL_COMPILER)
-#pragma warning(disable : 2282)
-#endif
-#if defined(__GNUC__MINOR__) || defined(__clang__)
+#if defined(__GNUC_MINOR__) && !defined(__INTEL_COMPILER)
 #pragma GCC diagnostic pop
+#elif defined(__clang__)
+#pragma clang diagnostic pop
 #endif
 }
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -383,6 +383,13 @@ TEST_CASE("available_chunks_test_json", "[serial][json]")
 TEST_CASE("multiple_series_handles_test", "[serial]")
 {
     /*
+     * clang also understands these pragmas.
+     */
+#if defined(__GNUC__MINOR__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    /*
      * First test: No premature flushes through destructor when another copy
      * is still around
      */
@@ -424,6 +431,12 @@ TEST_CASE("multiple_series_handles_test", "[serial]")
          */
         series_ptr->flush();
     }
+#if defined(__INTEL_COMPILER)
+#pragma warning(disable : 2282)
+#endif
+#if defined(__GNUC__MINOR__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 void close_iteration_test(std::string file_ending)


### PR DESCRIPTION
Other backports:

* https://github.com/openPMD/openPMD-api/pull/1223
* https://github.com/openPMD/openPMD-api/pull/1268 does not affect 0.14.5
* https://github.com/openPMD/openPMD-api/pull/1260
* https://github.com/openPMD/openPMD-api/pull/1213 (only the SerialIOTests.cpp part is relevant)
* https://github.com/openPMD/openPMD-api/pull/1224